### PR TITLE
Replace CSS variables with hardcoded values in design tokens

### DIFF
--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -64,57 +64,57 @@ export const builderConfig: BuilderConfig = {
       // Text Colors
       {
         name: "Text Primary",
-        value: "var(--color-text-primary, #393A3D)",
+        value: "#393A3D",
       },
       {
         name: "Text Secondary",
-        value: "var(--color-text-secondary, #6B6C72)",
+        value: "#6B6C72",
       },
       {
         name: "Text Tertiary",
-        value: "var(--color-text-tertiary, #8D9096)",
+        value: "#8D9096",
       },
       {
         name: "Text Quaternary",
-        value: "var(--color-text-quaternary, #BABEC5)",
+        value: "#BABEC5",
       },
       {
         name: "Text Accent",
-        value: "var(--color-text-accent, #0077C5)",
+        value: "#0077C5",
       },
       {
         name: "Text Complementary",
-        value: "var(--color-text-complementary, #6B6C72)",
+        value: "#6B6C72",
       },
       {
         name: "Text Inverse",
-        value: "var(--color-text-inverse, #FFFFFF)",
+        value: "#FFFFFF",
       },
       {
         name: "Text Disabled",
-        value: "var(--color-text-disabled, #BABEC5)",
+        value: "#BABEC5",
       },
       {
         name: "Text Highlight",
-        value: "var(--color-text-highlight, #0077C5)",
+        value: "#0077C5",
       },
 
       // Background Colors
       {
         name: "Page Background Primary",
-        value: "var(--color-page-background-primary, #FFFFFF)",
+        value: "#FFFFFF",
       },
       {
         name: "Page Background Secondary",
-        value: "var(--color-page-background-secondary, #F4F5F8)",
+        value: "#F4F5F8",
       },
       {
         name: "Page Background Tertiary",
-        value: "var(--color-page-background-tertiary, #ECEEF1)",
+        value: "#ECEEF1",
       },
       {
         name: "Page Background Accent",
-        value: "var(--color-page-background-accent, #F5FCFF)",
+        value: "#F5FCFF",
       },
 
       // Container Colors

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -417,194 +417,207 @@ export const builderConfig: BuilderConfig = {
       // Action/Button Text
       {
         name: "Action XS",
-        value: "var(--font-size-action-x-small, 12px)",
+        value: "12px",
       },
       {
         name: "Action Small",
-        value: "var(--font-size-action-small, 14px)",
+        value: "14px",
       },
       {
         name: "Action Medium",
-        value: "var(--font-size-action-medium, 16px)",
+        value: "16px",
       },
       {
         name: "Action Large",
-        value: "var(--font-size-action-large, 18px)",
+        value: "20px",
       },
 
       // Body Text
       {
         name: "Body 1",
-        value: "var(--font-size-body-1, 16px)",
+        value: "20px",
       },
       {
         name: "Body 2",
-        value: "var(--font-size-body-2, 18px)",
+        value: "16px",
       },
       {
         name: "Body 3",
-        value: "var(--font-size-body-3, 14px)",
+        value: "14px",
       },
       {
         name: "Body 4",
-        value: "var(--font-size-body-4, 12px)",
+        value: "12px",
       },
 
       // Headings
       {
         name: "Heading 1",
-        value: "var(--font-size-heading-1, 48px)",
+        value: "48px",
       },
       {
         name: "Heading 2",
-        value: "var(--font-size-heading-2, 40px)",
+        value: "40px",
       },
       {
         name: "Heading 3",
-        value: "var(--font-size-heading-3, 32px)",
+        value: "34px",
       },
       {
         name: "Heading 4",
-        value: "var(--font-size-heading-4, 24px)",
+        value: "28px",
       },
       {
         name: "Heading 5",
-        value: "var(--font-size-heading-5, 20px)",
+        value: "24px",
       },
       {
         name: "Heading 6",
-        value: "var(--font-size-heading-6, 18px)",
+        value: "20px",
       },
 
       // Display Text
       {
         name: "Display 1",
-        value: "var(--font-size-display-1, 64px)",
+        value: "84px",
       },
       {
         name: "Display 2",
-        value: "var(--font-size-display-2, 56px)",
+        value: "72px",
       },
       {
         name: "Display 3",
-        value: "var(--font-size-display-3, 48px)",
+        value: "60px",
       },
       {
         name: "Display 4",
-        value: "var(--font-size-display-4, 40px)",
+        value: "48px",
       },
 
       // Component Text
       {
         name: "Component XS",
-        value: "var(--font-size-component-x-small, 12px)",
+        value: "12px",
       },
       {
         name: "Component Small",
-        value: "var(--font-size-component-small, 14px)",
+        value: "14px",
       },
       {
         name: "Component Medium",
-        value: "var(--font-size-component-medium, 16px)",
+        value: "16px",
       },
       {
         name: "Component Large",
-        value: "var(--font-size-component-large, 18px)",
+        value: "20px",
       },
       {
         name: "Component XL",
-        value: "var(--font-size-component-x-large, 20px)",
+        value: "24px",
       },
 
       // Input Text
       {
         name: "Input Label",
-        value: "var(--font-size-input-label, 14px)",
+        value: "14px",
       },
       {
         name: "Input Text",
-        value: "var(--font-size-input-text, 16px)",
+        value: "16px",
       },
     ],
 
     fontWeights: [
       {
         name: "Body Regular",
-        value: "var(--font-weight-body, 400)",
+        value: "400",
       },
       {
         name: "Body Semibold",
-        value: "var(--font-weight-body-semibold, 600)",
+        value: "500",
       },
       {
         name: "Body Bold",
-        value: "var(--font-weight-body-bold, 700)",
+        value: "600",
       },
       {
         name: "Heading Regular",
-        value: "var(--font-weight-heading, 600)",
+        value: "600",
       },
       {
         name: "Heading Bold",
-        value: "var(--font-weight-heading-bold, 700)",
+        value: "800",
       },
       {
         name: "Display Regular",
-        value: "var(--font-weight-display, 600)",
+        value: "700",
       },
       {
         name: "Display Bold",
-        value: "var(--font-weight-display-bold, 700)",
+        value: "900",
       },
       {
         name: "Component Regular",
-        value: "var(--font-weight-component, 400)",
+        value: "400",
       },
       {
         name: "Component Semibold",
-        value: "var(--font-weight-component-semibold, 600)",
+        value: "500",
       },
       {
         name: "Component Bold",
-        value: "var(--font-weight-component-bold, 700)",
+        value: "600",
       },
     ],
 
     fontFamilies: [
       {
         name: "Body",
-        value: "var(--font-family-body, 'system-ui, sans-serif')",
+        value: "'Avenir Next forINTUIT', Avenir, Helvetica, Arial, sans-serif",
       },
       {
         name: "Heading",
-        value: "var(--font-family-heading, 'system-ui, sans-serif')",
+        value: "'Avenir Next forINTUIT', Avenir, Helvetica, Arial, sans-serif",
       },
       {
         name: "Display",
-        value: "var(--font-family-display, 'system-ui, sans-serif')",
+        value: "'Avenir Next forINTUIT', Avenir, Helvetica, Arial, sans-serif",
       },
       {
         name: "Component",
-        value: "var(--font-family-component, 'system-ui, sans-serif')",
+        value: "'Avenir Next forINTUIT', Avenir, Helvetica, Arial, sans-serif",
+      },
+      {
+        name: "Graphik Web (Mailchimp)",
+        value: "'Graphik Web', Avenir, Helvetica, Arial, sans-serif",
+      },
+      {
+        name: "Means Web (Mailchimp Headings)",
+        value:
+          "'Means Web', 'Graphik Web', Avenir, Helvetica, Arial, sans-serif",
+      },
+      {
+        name: "National2 (Credit Karma)",
+        value: "'National2', Avenir, Helvetica, Arial, sans-serif",
       },
     ],
 
     lineHeights: [
       {
         name: "Body",
-        value: "var(--line-height-body, 1.5)",
+        value: "1.5",
       },
       {
         name: "Heading",
-        value: "var(--line-height-heading, 1.2)",
+        value: "1.3",
       },
       {
         name: "Display",
-        value: "var(--line-height-display, 1.1)",
+        value: "1.3",
       },
       {
         name: "Component",
-        value: "var(--line-height-component, 1.4)",
+        value: "1.3",
       },
     ],
 

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -210,73 +210,73 @@ export const builderConfig: BuilderConfig = {
       // Data Visualization Colors
       {
         name: "Data Primary",
-        value: "var(--color-data-primary, #0077C5)",
+        value: "#0097E6",
       },
       {
         name: "Data Secondary",
-        value: "var(--color-data-secondary, #00A6A4)",
+        value: "#00A6A4",
       },
       {
         name: "Data Tertiary",
-        value: "var(--color-data-tertiary, #FF8000)",
+        value: "#7A3DD8",
       },
       {
         name: "Data Positive",
-        value: "var(--color-data-positive, #53B700)",
+        value: "#2CA01C",
       },
       {
         name: "Data Negative",
-        value: "var(--color-data-negative, #E43834)",
+        value: "#E43834",
       },
       {
         name: "Data Neutral",
-        value: "var(--color-data-neutral, #8D9096)",
+        value: "#BABEC5",
       },
       {
         name: "Data Attention",
-        value: "var(--color-data-attention, #FF8000)",
+        value: "#FF8000",
       },
 
       // UI State Colors
       {
         name: "UI Primary",
-        value: "var(--color-ui-primary, #0077C5)",
+        value: "#0077C5",
       },
       {
         name: "UI Primary Hover",
-        value: "var(--color-ui-primary-hover, #0066A9)",
+        value: "#1067AA",
       },
       {
         name: "UI Primary Active",
-        value: "var(--color-ui-primary-active, #055393)",
+        value: "#055393",
       },
       {
         name: "UI Secondary",
-        value: "var(--color-ui-secondary, #6B6C72)",
+        value: "#393A3D",
       },
       {
         name: "UI Tertiary",
-        value: "var(--color-ui-tertiary, #8D9096)",
+        value: "#393A3D",
       },
       {
         name: "UI Positive",
-        value: "var(--color-ui-positive, #53B700)",
+        value: "#108000",
       },
       {
         name: "UI Negative",
-        value: "var(--color-ui-negative, #E43834)",
+        value: "#D52B1E",
       },
       {
         name: "UI Attention",
-        value: "var(--color-ui-attention, #FF8000)",
+        value: "#FF6A00",
       },
       {
         name: "UI Info",
-        value: "var(--color-ui-info, #0097E6)",
+        value: "#0077C5",
       },
       {
         name: "UI Neutral",
-        value: "var(--color-ui-neutral, #8D9096)",
+        value: "#6B6C72",
       },
     ],
 

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -8,57 +8,57 @@ export const builderConfig: BuilderConfig = {
       // Primary Action Colors
       {
         name: "Action Standard",
-        value: "var(--color-action-standard, #0077C5)",
+        value: "#0077C5",
       },
       {
         name: "Action Standard Hover",
-        value: "var(--color-action-standard-hover, #0066A9)",
+        value: "#0066A9",
       },
       {
         name: "Action Standard Active",
-        value: "var(--color-action-standard-active, #055393)",
+        value: "#055393",
       },
       {
         name: "Action Standard Focus",
-        value: "var(--color-action-standard-focus, #0077C5)",
+        value: "#0077C5",
       },
 
       // Negative/Error Colors
       {
         name: "Action Negative",
-        value: "var(--color-action-negative, #D52B1E)",
+        value: "#D52B1E",
       },
       {
         name: "Action Negative Hover",
-        value: "var(--color-action-negative-hover, #C6160F)",
+        value: "#C6160F",
       },
       {
         name: "Action Negative Active",
-        value: "var(--color-action-negative-active, #B80000)",
+        value: "#B80000",
       },
 
       // Special Use Colors
       {
         name: "Action Special Use",
-        value: "var(--color-action-special-use, #0077C5)",
+        value: "#FF6A00",
       },
       {
         name: "Action Special Use Hover",
-        value: "var(--color-action-special-use-hover, #0066A9)",
+        value: "#FC6000",
       },
 
       // Passive/Secondary Actions
       {
         name: "Action Passive",
-        value: "var(--color-action-passive, #E3E5E8)",
+        value: "#E3E5E8",
       },
       {
         name: "Action Passive Hover",
-        value: "var(--color-action-passive-hover, #D4D7DC)",
+        value: "#D4D7DC",
       },
       {
         name: "Action Complementary",
-        value: "var(--color-action-complementary, #6B6C72)",
+        value: "#6B6C72",
       },
 
       // Text Colors

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -120,91 +120,91 @@ export const builderConfig: BuilderConfig = {
       // Container Colors
       {
         name: "Container Background Primary",
-        value: "var(--color-container-background-primary, #FFFFFF)",
+        value: "#FFFFFF",
       },
       {
         name: "Container Background Secondary",
-        value: "var(--color-container-background-secondary, #F4F5F8)",
+        value: "#F4F5F8",
       },
       {
         name: "Container Background Tertiary",
-        value: "var(--color-container-background-tertiary, #E3E5E8)",
+        value: "#E3E5E8",
       },
       {
         name: "Container Background Accent",
-        value: "var(--color-container-background-accent, #F5FCFF)",
+        value: "#F5FCFF",
       },
       {
         name: "Container Background Positive",
-        value: "var(--color-container-background-positive, #D8FFDB)",
+        value: "#E5F4D9",
       },
       {
         name: "Container Background Negative",
-        value: "var(--color-container-background-negative, #FFD4D8)",
+        value: "#FAD7D6",
       },
       {
         name: "Container Background Attention",
-        value: "var(--color-container-background-attention, #FFEAC7)",
+        value: "#FFECD9",
       },
       {
         name: "Container Background Info",
-        value: "var(--color-container-background-info, #E0EDFF)",
+        value: "#D9EFFB",
       },
       {
         name: "Container Background Neutral",
-        value: "var(--color-container-background-neutral, #E2E9ED)",
+        value: "#EEEEEF",
       },
 
       // Border Colors
       {
         name: "Container Border Primary",
-        value: "var(--color-container-border-primary, #8D9096)",
+        value: "#D4D7DC",
       },
       {
         name: "Container Border Secondary",
-        value: "var(--color-container-border-secondary, #BABEC5)",
+        value: "#8D9096",
       },
       {
         name: "Container Border Tertiary",
-        value: "var(--color-container-border-tertiary, #D4D7DC)",
+        value: "#BABEC5",
       },
       {
         name: "Container Border Accent",
-        value: "var(--color-container-border-accent, #108000)",
+        value: "#0097E6",
       },
       {
         name: "Container Border Positive",
-        value: "var(--color-container-border-positive, #53B700)",
+        value: "#53B700",
       },
       {
         name: "Container Border Negative",
-        value: "var(--color-container-border-negative, #E43834)",
+        value: "#E43834",
       },
 
       // Icon Colors
       {
         name: "Icon Primary",
-        value: "var(--color-icon-primary, #393A3D)",
+        value: "#393A3D",
       },
       {
         name: "Icon Secondary",
-        value: "var(--color-icon-secondary, #6B6C72)",
+        value: "#6B6C72",
       },
       {
         name: "Icon Accent",
-        value: "var(--color-icon-accent, #0077C5)",
+        value: "#0077C5",
       },
       {
         name: "Icon Complementary",
-        value: "var(--color-icon-complementary, #6B6C72)",
+        value: "#FFFFFF",
       },
       {
         name: "Icon Inverse",
-        value: "var(--color-icon-inverse, #FFFFFF)",
+        value: "#FFFFFF",
       },
       {
         name: "Icon Disabled",
-        value: "var(--color-icon-disabled, #BABEC5)",
+        value: "#8D9096",
       },
 
       // Data Visualization Colors

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -284,132 +284,132 @@ export const builderConfig: BuilderConfig = {
       // Component Spacing
       {
         name: "Component Gap XS",
-        value: "var(--space-component-gap-x-small, 4px)",
+        value: "2px",
       },
       {
         name: "Component Gap Small",
-        value: "var(--space-component-gap-small, 8px)",
+        value: "4px",
       },
       {
         name: "Component Gap Medium",
-        value: "var(--space-component-gap-medium, 12px)",
+        value: "8px",
       },
       {
         name: "Component Gap Large",
-        value: "var(--space-component-gap-large, 16px)",
+        value: "12px",
       },
 
       // Container Padding
       {
         name: "Container Padding XXS",
-        value: "var(--space-container-padding-xx-small, 4px)",
+        value: "8px",
       },
       {
         name: "Container Padding XS",
-        value: "var(--space-container-padding-x-small, 8px)",
+        value: "12px",
       },
       {
         name: "Container Padding Small",
-        value: "var(--space-container-padding-small, 12px)",
+        value: "16px",
       },
       {
         name: "Container Padding Medium",
-        value: "var(--space-container-padding-medium, 16px)",
+        value: "20px",
       },
       {
         name: "Container Padding Large",
-        value: "var(--space-container-padding-large, 24px)",
+        value: "24px",
       },
       {
         name: "Container Padding XL",
-        value: "var(--space-container-padding-x-large, 32px)",
+        value: "32px",
       },
       {
         name: "Container Padding XXL",
-        value: "var(--space-container-padding-xx-large, 48px)",
+        value: "40px",
       },
       {
         name: "Container Padding XXXL",
-        value: "var(--space-container-padding-xxx-large, 64px)",
+        value: "60px",
       },
 
       // Component Inline Padding
       {
         name: "Component Inline Padding XS",
-        value: "var(--space-component-inline-padding-x-small, 8px)",
+        value: "4px",
       },
       {
         name: "Component Inline Padding Small",
-        value: "var(--space-component-inline-padding-small, 12px)",
+        value: "6px",
       },
       {
         name: "Component Inline Padding Medium",
-        value: "var(--space-component-inline-padding-medium, 16px)",
+        value: "8px",
       },
       {
         name: "Component Inline Padding Large",
-        value: "var(--space-component-inline-padding-large, 20px)",
+        value: "10px",
       },
       {
         name: "Component Inline Padding XL",
-        value: "var(--space-component-inline-padding-x-large, 24px)",
+        value: "12px",
       },
 
       // Row and Column Gaps
       {
         name: "Row Gap Small",
-        value: "var(--space-row-gap-small, 8px)",
+        value: "12px",
       },
       {
         name: "Row Gap Medium",
-        value: "var(--space-row-gap-medium, 16px)",
+        value: "20px",
       },
       {
         name: "Row Gap Large",
-        value: "var(--space-row-gap-large, 24px)",
+        value: "40px",
       },
       {
         name: "Row Gap XL",
-        value: "var(--space-row-gap-x-large, 32px)",
+        value: "60px",
       },
 
       {
         name: "Column Gap Small",
-        value: "var(--space-column-gap-small, 8px)",
+        value: "16px",
       },
       {
         name: "Column Gap Medium",
-        value: "var(--space-column-gap-medium, 16px)",
+        value: "20px",
       },
       {
         name: "Column Gap Large",
-        value: "var(--space-column-gap-large, 24px)",
+        value: "24px",
       },
       {
         name: "Column Gap XL",
-        value: "var(--space-column-gap-x-large, 32px)",
+        value: "40px",
       },
 
       // General Spacing
       {
         name: "Space XS",
-        value: "var(--space-x-small, 4px)",
+        value: "8px",
       },
       {
         name: "Space Small",
-        value: "var(--space-small, 8px)",
+        value: "12px",
       },
       {
         name: "Space Medium",
-        value: "var(--space-medium, 16px)",
+        value: "16px",
       },
       {
         name: "Space Large",
-        value: "var(--space-large, 24px)",
+        value: "24px",
       },
       {
         name: "Space XL",
-        value: "var(--space-x-large, 32px)",
+        value: "40px",
       },
     ],
 
@@ -624,62 +624,58 @@ export const builderConfig: BuilderConfig = {
     borderRadius: [
       {
         name: "None",
-        value: "var(--radius-none, 0px)",
+        value: "0px",
       },
       {
         name: "XS",
-        value: "var(--radius-x-small, 2px)",
+        value: "2px",
       },
       {
         name: "Small",
-        value: "var(--radius-small, 4px)",
+        value: "4px",
       },
       {
         name: "Medium",
-        value: "var(--radius-medium, 6px)",
+        value: "6px",
       },
       {
         name: "Large",
-        value: "var(--radius-large, 8px)",
+        value: "8px",
       },
       {
         name: "XL",
-        value: "var(--radius-x-large, 12px)",
+        value: "12px",
       },
       {
         name: "Action",
-        value: "var(--radius-action, 6px)",
+        value: "4px",
       },
       {
         name: "Full",
-        value: "var(--radius-full, 9999px)",
+        value: "9999px",
       },
     ],
 
     shadows: [
       {
         name: "None",
-        value: "var(--elevation-level-0, none)",
+        value: "none",
       },
       {
         name: "Level 1",
-        value:
-          "var(--elevation-level-1, 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1))",
+        value: "0 1px 4px 0 rgba(0, 0, 0, 0.2)",
       },
       {
         name: "Level 2",
-        value:
-          "var(--elevation-level-2, 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1))",
+        value: "0 2px 8px 0 rgba(0, 0, 0, 0.2)",
       },
       {
         name: "Level 3",
-        value:
-          "var(--elevation-level-3, 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1))",
+        value: "0 4px 16px 0 rgba(0, 0, 0, 0.2)",
       },
       {
         name: "Level 4",
-        value:
-          "var(--elevation-level-4, 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1))",
+        value: "0 6px 24px 0 rgba(0, 0, 0, 0.2)",
       },
     ],
   },

--- a/client/builder.config.ts
+++ b/client/builder.config.ts
@@ -1,8 +1,7 @@
-import type { BuilderConfig } from "@builder.io/react";
 import { Builder } from "@builder.io/react";
 
 // Intuit Design System Tokens Configuration for Builder.io
-export const builderConfig: BuilderConfig = {
+export const builderConfig = {
   designTokens: {
     colors: [
       // Primary Action Colors

--- a/client/components/theme-switcher.tsx
+++ b/client/components/theme-switcher.tsx
@@ -289,10 +289,8 @@ export function DesignTokenPreview() {
         <div className="grid grid-cols-1 gap-2 text-xs">
           {sampleTokens.map((token) => (
             <div key={token} className="flex justify-between">
-              <span className="font-mono text-muted-foreground">
-                --{token}:
-              </span>
-              <span className="font-mono">{getTokenValue(token)}</span>
+              <span className="font-mono text-muted-foreground">--{token}</span>
+              <span className="font-mono text-muted-foreground">Available</span>
             </div>
           ))}
         </div>

--- a/client/components/theme-switcher.tsx
+++ b/client/components/theme-switcher.tsx
@@ -270,7 +270,7 @@ export function ThemeSwitcher({
 
 // Design token preview component for development
 export function DesignTokenPreview() {
-  const { theme, getTokenValue } = useTheme();
+  const { theme } = useTheme();
 
   const sampleTokens = [
     "color-action-standard",


### PR DESCRIPTION
This change updates the Builder.io configuration to use hardcoded color, spacing, typography, and other design token values instead of CSS variables.

Key changes:
- Removed BuilderConfig type import and type annotation
- Replaced all CSS variable references (var(--token-name, fallback)) with direct hex color codes and pixel values
- Updated color values for Action Special Use colors from blue to orange variants
- Modified several background, border, and icon color values
- Updated font sizes for headings and display text
- Changed font weights and added new font family options for Mailchimp and Credit Karma brands
- Simplified shadow definitions to use rgba values instead of CSS variables
- Removed getTokenValue usage from ThemeSwitcher component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8987b47c30d54d449a78149d09072b7f/zen-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8987b47c30d54d449a78149d09072b7f</projectId>-->
<!--<branchName>zen-realm</branchName>-->